### PR TITLE
use a submodule to pull in opennms dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ version: 2.1
 executors:
   build-executor:
     docker:
-      - image: opennms/build-env:jdk8_1.2
+      - image: cimg/openjdk:11.0
 
   ghr-executor:
     docker:
-      - image: opennms/ghr:0.12.0-b1
+      - image: opennms/ghr:0.13.0
 
 commands:
   cached-checkout:
@@ -16,12 +16,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
+            - source-v2-{{ .Branch }}-{{ .Revision }}
+            - source-v2-{{ .Branch }}-
+            - source-v2-
       - checkout
+      - run:
+          command: git submodule update --init
       - save_cache:
-          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          key: source-v2-{{ .Branch }}-{{ .Revision }}
           paths:
             - ".git"
 
@@ -34,8 +36,8 @@ commands:
             find . -type f -name "pom.xml" -exec sha256sum "{}" \; | sort -nr >> maven-dependency-cache.key
       - restore_cache:
           keys:
-            - maven-dependencies-v2-{{ checksum "maven-dependency-cache.key" }}
-            - maven-dependencies-v2-
+            - maven-dependencies-v3-{{ checksum "maven-dependency-cache.key" }}
+            - maven-dependencies-v3-
       - run:
           name: Remove OpenNMS and MQTT Plugin artifacts from cache
           command: |
@@ -45,7 +47,7 @@ commands:
     description: "Maven: Save cache"
     steps:
       - save_cache:
-          key: maven-dependencies-v2-{{ checksum "maven-dependency-cache.key" }}
+          key: maven-dependencies-v3-{{ checksum "maven-dependency-cache.key" }}
           paths:
             - ~/.m2
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "opennms"]
+	path = opennms
+	url = https://github.com/OpenNMS/opennms.git

--- a/README.MD
+++ b/README.MD
@@ -44,17 +44,34 @@ The architecture of the feature is shown in the following diagram.
 (Please note that the present version does not use the new OpenNMS streaming API and so is backwards compatible with Meridian 2017. 
 It interacts with OpenNMS in much the same way as the design intent of the streaming API.)
 
-A docker-compose project with all the correct dependencies is also provided in the sub project mqtt-docker-compose. 
-If you first build this project, you can then run the docker-compose project.
+First, clone and initialize the repo:
+
+```
+# clone the repo
+git clone https://github.com/opennms-forge/opennms-mqtt-plugin.git
+cd opennms-mqtt-plugin
+
+# fetch the opennms code associated with the plugin
+git submodule update --init
+```
 
 You need to target the build against the correct major version of OpenNMS.
 To do this, edit the parent pom.xml and change the property
 
-''''
-    <org.opennms.version>24.1.1</org.opennms.version>
-''''
+```
+    <org.opennms.version>32.0.5</org.opennms.version>
+```
     
 To match the version you are targeting. 
+NOTE: if you change this, you will also need to make sure the `opennms/` submodule is updated to match.
+
+```
+cd opennms
+git fetch --all
+git reset --hard <opennms-tag-or-branch-or-commit>
+cd ..
+git add opennms
+```
 
 to build used 
 ```

--- a/README.MD
+++ b/README.MD
@@ -4,6 +4,15 @@ This OpenNMS plugin adds the ability for OpenNMS to received streaming measureme
 
 There is a video describing this project from the OpenNMS User Conference here https://www.youtube.com/watch?v=r8GXg_DSUM4
 
+Note:
+this branch also includes a git submodule of opennms depencencies checked out from git and built locally.
+To build run 
+
+```
+git submodule update --init  
+mvn clean install
+```
+
 This version (0.0.8) is designed for OpenNMS versions 30 or greater. 
 0.0.7 tested with OpenNMS 27
 0.0.6 tested with OpenNMS 25.1.1

--- a/README.MD
+++ b/README.MD
@@ -4,16 +4,7 @@ This OpenNMS plugin adds the ability for OpenNMS to received streaming measureme
 
 There is a video describing this project from the OpenNMS User Conference here https://www.youtube.com/watch?v=r8GXg_DSUM4
 
-Note:
-this branch also includes a git submodule of opennms depencencies checked out from git and built locally.
-To build run 
-
-```
-git submodule update --init  
-mvn clean install
-```
-
-This version (0.0.8) is designed for OpenNMS versions 30 or greater. 
+This version (0.0.9) is designed for OpenNMS versions 32 or greater. 
 0.0.7 tested with OpenNMS 27
 0.0.6 tested with OpenNMS 25.1.1
 (Use version 0.0.4 with versions before 25)
@@ -72,7 +63,8 @@ To do this, edit the parent pom.xml and change the property
 ```
     
 To match the version you are targeting. 
-NOTE: if you change this, you will also need to make sure the `opennms/` submodule is updated to match.
+
+NOTE: if you change this version, you will also need to make sure the linked `opennms/` submodule is updated to the matching tag.
 
 ```
 cd opennms
@@ -82,10 +74,17 @@ cd ..
 git add opennms
 ```
 
-to build used 
+to build use 
 ```
 mvn build install
 ```
+
+Once you have built the OpenNMS depencencies - or if you have already place them in your .m2 repository through a seperate OpenNMS build, you can build this module while skipping the opennms compile step using
+
+```
+mvn clean install -DskipOpennmsBuild 
+```
+
 
 Io install in OpenNMS, 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
       <productFeatureRepository>mvn:${project.groupId}/${productName}/${project.version}/xml/features</productFeatureRepository>
 
       <org.opennms.version>32.0.5</org.opennms.version>
+      <opennms.projects>
+          org.opennms.core:org.opennms.core.api,
+          org.opennms.core.ipc.sink:org.opennms.core.ipc.sink.common,
+          org.opennms.osgi:opennms-osgi-core,
+          org.opennms:opennms-dao,
+          org.opennms:opennms-model,
+          org.opennms.protocols:org.opennms.protocols.xml
+      </opennms.projects>
 
       <slf4jVersion>1.7.21</slf4jVersion>
       <log4j2Version>2.8.2</log4j2Version>
@@ -52,6 +60,56 @@
    </modules>
 
    <build>
+
+      <!-- before we do anything else, build the bits of OpenNMS we need for deep-introspection -->
+      <plugins>
+         <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.1.0</version>
+            <inherited>false</inherited>
+            <executions>
+               <execution>
+                  <id>build-opennms-components</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                     <goal>exec</goal>
+                  </goals>
+                  <configuration>
+                     <skip>${skipOpennmsBuild}</skip>
+                     <executable>${maven.home}/bin/mvn</executable>
+                     <arguments>
+                        <argument>-DskipTests=true</argument>
+                        <argument>-Dbuild.skip.tarball=true</argument>
+                        <argument>--also-make</argument>
+                        <argument>--projects</argument>
+                        <argument>${opennms.projects}</argument>
+                        <argument>install</argument>
+                     </arguments>
+                     <workingDirectory>opennms</workingDirectory>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>clean-opennms-components</id>
+                  <phase>clean</phase>
+                  <goals>
+                     <goal>exec</goal>
+                  </goals>
+                  <configuration>
+                     <skip>${skipOpennmsBuild}</skip>
+                     <executable>${maven.home}/bin/mvn</executable>
+                     <arguments>
+                        <argument>--also-make</argument>
+                        <argument>--projects</argument>
+                        <argument>${opennms.projects}</argument>
+                        <argument>clean</argument>
+                     </arguments>
+                     <workingDirectory>opennms</workingDirectory>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
 
       <pluginManagement>
          <plugins>
@@ -484,56 +542,13 @@
    </pluginRepositories>
 
    <repositories>
-      <!-- uncomment to pick up local OpenNMS build artifacts from local repo -->
-<!--       <repository> -->
-<!--          <id>importm2</id> -->
-<!--          <name>virtual machine importm2</name> -->
-<!--          <url>http://192.168.80.130:8181/repository/importm2</url> -->
-<!--          <releases> -->
-<!--             <enabled>true</enabled> -->
-<!--             <updatePolicy>never</updatePolicy> -->
-<!--          </releases> -->
-<!--          <snapshots> -->
-<!--             <enabled>true</enabled> -->
-<!--             <updatePolicy>${updatePolicy}</updatePolicy> -->
-<!--          </snapshots> -->
-<!--       </repository> -->
-      
       <repository>
-         <id>vaadin-snapshots</id>
-         <releases>
-            <enabled>false</enabled>
-         </releases>
-         <snapshots>
-            <enabled>true</enabled>
-         </snapshots>
-         <url>https://maven.opennms.org/content/groups/vaadin-snapshot/</url>
-      </repository>
-      <repository>
-         <id>vaadin-addons</id>
-         <url>https://maven.opennms.org/content/groups/vaadin.com-addons/</url>
-      </repository>
-      <repository>
-         <snapshots>
-            <enabled>false</enabled>
-         </snapshots>
-         <releases>
-            <enabled>true</enabled>
-         </releases>
          <id>opennms-repo</id>
-         <name>OpenNMS Repository</name>
-         <url>https://maven.opennms.org/content/groups/opennms.org-release</url>
-      </repository>
-      <repository>
-         <id>opennms-snapshots</id>
-         <name>OpenNMS Snapshot Maven Repository</name>
+         <name>OpenNMS Mega-Repository</name>
+         <url>https://maven.opennms.org/repository/everything/</url>
          <snapshots>
-            <enabled>true</enabled>
-         </snapshots>
-         <releases>
             <enabled>false</enabled>
-         </releases>
-         <url>https://maven.opennms.org/content/groups/opennms.org-snapshot</url>
+         </snapshots>
       </repository>
    </repositories>
 


### PR DESCRIPTION
This PR adds a git submodule that pulls in the OpenNMS horizon codebase (currently set to the contents of the `opennms-32.0.5-1` tag).

It adds a plugin config using the `exec-maven-plugin` to auto-build (and auto-clean) a subset of the OpenNMS codebase necessary to build the MQTT plugin.

I made some minor updates to the docs to note how you initialize your repo.
If you've already checked out the mqtt repo, once you update you can just do the submodule bit to have things work.